### PR TITLE
List local dumps with view and download options

### DIFF
--- a/frontend/src/Dumps.vue
+++ b/frontend/src/Dumps.vue
@@ -3,15 +3,56 @@
         <b-row align-h="center" align-v="center">
             <flower-spinner :animation-duration="2500" :size="100" color="#b95e42" v-show="loading"/>
         </b-row>
+        <b-row>
+          <b-col>
+              <b-table striped hover fixed :items="items" :fields="fields">
+              <template slot="actions" slot-scope="row">
+                <b-btn size="sm" :href="`/api/dump/${row.item.pid}.${row.item.recording}.jfr`">Download</b-btn>
+                <b-btn size="sm" :href="`#/flames/${row.item.pid}/${row.item.recording}`">View flames</b-btn>
+              </template>
+              </b-table>
+          </b-col>
+        </b-row>
         <back></back>
     </div>
 </template>
 <script>
 export default {
+  name: "dumps",
   data () {
     return {
-      loading: true
+      loading: true,
+      fields: [
+        {
+          key: "pid",
+          lable: "PID",
+          sortable: true
+        },
+        {
+          key: "recording",
+          label: "Recording #"
+        },
+        "actions"
+      ],
+      items: []
     };
+  },
+  mounted () {
+    const url = "/api/dumps/";
+    this.$http
+      .get(url)
+      .then(response => {
+        this.items = response.data;
+        this.loading = false;
+      })
+      .catch(error => {
+        this.$notify({
+          title: error.message,
+          text: error.response.data,
+          type: "error",
+          duration: 10000
+        });
+      });
   }
 };
 </script>

--- a/frontend/src/Home.vue
+++ b/frontend/src/Home.vue
@@ -1,6 +1,6 @@
 <template>
 <div>
-    <b-row>
+    <b-row ref="table">
         <b-col>
             <b-table striped hover fixed :items="items" :fields="fields">
             <template slot="name" slot-scope="row">
@@ -31,7 +31,7 @@
     <b-row class="text-left">
         <b-col>
           <a :href="`#/dumps`">
-            View all available dumps
+            View all local dumps
           </a>
         </b-col>
     </b-row>
@@ -73,7 +73,7 @@ export default {
       // and not reactive by default.
       this.$set(item, "loading", true);
       this.$http
-        .get("/api/start/" + item.pid)
+        .post("/api/start/" + item.pid)
         .then(response => {
           item.state = response.data.state;
           item.recording = response.data.recording;
@@ -86,7 +86,7 @@ export default {
     stop: function (item) {
       this.$set(item, "loading", true);
       this.$http
-        .get("/api/stop/" + item.pid + "/" + item.recording)
+        .post("/api/stop/" + item.pid + "/" + item.recording)
         .then(response => {
           item.state = response.data.state;
           item.loading = false;
@@ -98,7 +98,7 @@ export default {
     dump: function (item) {
       this.$set(item, "loading", true);
       this.$http
-        .get("/api/dump/" + item.pid + "/" + item.recording)
+        .post("/api/dump/" + item.pid + "/" + item.recording)
         .then(response => {
           this.$set(item, "hasDump", true);
           item.loading = false;
@@ -115,6 +115,12 @@ export default {
         duration: 10000
       });
     }
+  },
+  mounted () {
+    // this.$nextTick(function () {
+    //   this.$refs.table.scrollTop = 0;
+    // });
+    window.scrollTo(0, 0);
   }
 };
 </script>

--- a/src/main/java/flamegrapher/backend/JavaFlightRecorder.java
+++ b/src/main/java/flamegrapher/backend/JavaFlightRecorder.java
@@ -39,6 +39,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.web.RoutingContext;
 
 public class JavaFlightRecorder implements Profiler {
     private static final Logger logger = LoggerFactory.getLogger(JavaFlightRecorder.class);
@@ -291,6 +292,15 @@ public class JavaFlightRecorder implements Profiler {
                             handler.complete(results);                        
                         }
                     });
+    }
+    
+    @Override
+    public Future<Void> dumpFromLocal(String filename, RoutingContext rc) {
+        Future<Void> status = Future.future();
+        // File name example: 164722.1.jfr
+        String path = workingDir() + "/" + filename;
+        rc.response().sendFile(path, status);
+        return status;
     }
     
     @Override

--- a/src/main/java/flamegrapher/backend/Profiler.java
+++ b/src/main/java/flamegrapher/backend/Profiler.java
@@ -5,6 +5,7 @@ import flamegrapher.model.Item;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
 
 public interface Profiler {
     
@@ -31,4 +32,6 @@ public interface Profiler {
     void flameFromStorage(String storageKey, Future<StackFrame> handler);
 
     void saveFlame(String pid, String recording, Future<JsonObject> handler);
+
+    Future<Void> dumpFromLocal(String filename, RoutingContext rc);
 }


### PR DESCRIPTION
* Fixes https://github.com/flamegrapher/flamegrapher/issues/19
* Small abstraction leaks, e.g. UI specifies .jfr as file extension, but we're in a hurry :)
* UI only for local dumps for now, S3 will come soon
* Scroll top when coming back to home (it was annoying when we were coming back from a big flamegraph to have to scroll up to see the list of processes).