### PR TITLE
Ensure resource copying gets done in correct phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
 					<execution>
 						<id>copy-resources</id>
 						<!-- here the phase you need -->
-						<phase>validate</phase>
+						<phase>process-resources</phase>
 						<goals>
 							<goal>copy-resources</goal>
 						</goals>


### PR DESCRIPTION
Copying frontend/dist resources can be
attempted before they were generated resulting in the
jar missing critical resources.