### PR TITLE
Allow override of region and enable object prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Flamegrapher's configuration relies on [Vertx configuration module](https://vert
 * `FLAMEGRAPHER_HTTP_PORT`: HTTP listening port. Defaults to "8080";
 * `FLAMEGRAPHER_HTTP_SERVER`: Network interface on which server listens. Defaults to "0.0.0.0" which means all interfaces;
 * `FLAMEGRAPHER_S3_SERVER`: S3 server URL;
+* `FLAMEGRAPHER_S3_REGION`: S3 region - defaults to us-east-1
 * `FLAMEGRAPHER_S3_PORT`: S3 port;
 * `FLAMEGRAPHER_S3_ACCESS_KEY`: Access key;
 * `FLAMEGRAPHER_S3_SECRET_KEY`: Secret key;

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Flamegrapher's configuration relies on [Vertx configuration module](https://vert
 * `FLAMEGRAPHER_S3_SECRET_KEY`: Secret key;
 * `FLAMEGRAPHER_S3_DUMPS_BUCKET`: S3 bucket for dumps. Defaults to "dumps";
 * `FLAMEGRAPHER_S3_FLAMES_BUCKET`: S3 bucket for flames. Defaults to "flames";
+* `FLAMEGRAPHER_S3_DUMPS_PREFIX`: Prefix for objects stored in the dumps bucket. Allows one bucket to be used for dumps and flames. Defaults to ""
+* `FLAMEGRAPHER_S3_FLAMES_PREFIX`: Prefix for objects stored in the flames bucket. Allows one bucket to be used for dumps and flames. Defaults to ""
 * `FLAMEGRAPHER_JFR_DUMP_PATH`: Base directory for saving JFR dumps locally. Defaults to "/tmp/flamegrapher";
 * `JFR_SETTINGS_JDK9_PLUS`: [Optional] Custom settings for JDK 9+;
 * `JFR_SETTINGS_JDK7_OR_8`: [Optional] Custom settings for JDK 7 or 8.

--- a/src/main/java/flamegrapher/backend/JavaFlightRecorder.java
+++ b/src/main/java/flamegrapher/backend/JavaFlightRecorder.java
@@ -70,7 +70,7 @@ public class JavaFlightRecorder implements Profiler {
         this.vertx = vertx;
         this.config = config;
         s3ClientOptions = new S3ClientOptions().setHostnameOverride(config.getString("FLAMEGRAPHER_S3_SERVER"))
-                                               .setAwsRegion("us-east-1")
+                                               .setAwsRegion(config.getString("FLAMEGRAPHER_S3_REGION", "us-east-1"))
                                                .setAwsServiceName("s3")
                                                .setConnectTimeout(30000)
                                                .setGlobalTimeoutMs(30000L)

--- a/src/main/java/flamegrapher/backend/JavaFlightRecorder.java
+++ b/src/main/java/flamegrapher/backend/JavaFlightRecorder.java
@@ -63,6 +63,8 @@ public class JavaFlightRecorder implements Profiler {
     String recordingOption = "name";
     private final String dumpsBucket;
     private final String flamesBucket;
+    private final String dumpsPrefix;
+    private final String flamesPrefix;
 
     public JavaFlightRecorder(Vertx vertx, JsonObject config) {
         this.vertx = vertx;
@@ -79,6 +81,8 @@ public class JavaFlightRecorder implements Profiler {
         s3Client = new S3Client(vertx, s3ClientOptions);
         dumpsBucket = config.getString("FLAMEGRAPHER_S3_DUMPS_BUCKET", "dumps");
         flamesBucket = config.getString("FLAMEGRAPHER_S3_FLAMES_BUCKET", "flames");
+        dumpsPrefix = config.getString("FLAMEGRAPHER_S3_DUMPS_PREFIX", "");
+        flamesPrefix = config.getString("FLAMEGRAPHER_S3_FLAMES_PREFIX", "");
         try {
             Files.createDirectories(Paths.get(workingDir()));
         } catch (IOException e) {
@@ -271,6 +275,7 @@ public class JavaFlightRecorder implements Profiler {
                  if (asyncFile.succeeded()) {
                      String key = Paths.get(filename)
                                        .getFileName()
+                                       .resolve(dumpsPrefix)
                                        .toString();
                      s3Client.adaptiveUpload(dumpsBucket, key,
                              new AdaptiveUploadRequest(asyncFile.result()).withContentType("application/jfr-dump"),
@@ -300,6 +305,7 @@ public class JavaFlightRecorder implements Profiler {
 
                 String key = eventType + "." + Paths.get(filename)
                                                     .getFileName()
+                                                    .resolve(flamesPrefix)
                                                     .toString();
                 s3Client.putObject(flamesBucket, key,
                         new PutObjectRequest(buf).withContentType(APPLICATION_JSON_CHARSET_UTF_8), response -> {
@@ -355,7 +361,7 @@ public class JavaFlightRecorder implements Profiler {
 
     @Override
     public void listSavedDumps(Future<JsonArray> handler) {
-        s3Client.getBucket(dumpsBucket, new GetBucketRequest(), response -> {
+        s3Client.getBucket(dumpsBucket, new GetBucketRequest().withPrefix(dumpsPrefix), response -> {
             JsonArray result = new JsonArray();
             response.getData()
                     .getContentsList()
@@ -372,7 +378,7 @@ public class JavaFlightRecorder implements Profiler {
 
     @Override
     public void listSavedFlames(Future<JsonArray> handler) {
-        s3Client.getBucket(flamesBucket, new GetBucketRequest(), response -> {
+        s3Client.getBucket(flamesBucket, new GetBucketRequest().withPrefix(flamesPrefix), response -> {
             JsonArray result = new JsonArray();
             response.getData()
                     .getContentsList()


### PR DESCRIPTION
* Allow S3 region to be overridden from default of us-east-1
* Allow S3 objects to be stored under object prefixes to allow sharing of buckets between dumps and flames and also between different applications